### PR TITLE
Changes while testing

### DIFF
--- a/src/IOmisc.cpp
+++ b/src/IOmisc.cpp
@@ -1,15 +1,26 @@
 #include <opencv2/core.hpp>
-#include <opencv2/videoio.hpp>
-#include <opencv2/highgui.hpp>
-#include <opencv2/calib3d.hpp>
-#include <opencv2/imgproc.hpp>
-#include <ctime>
 #include <iostream>
 #include <fstream>
 
-#include "main_config.h"
+#include "config/config.h"
 #include "IOmisc.h"
 
+void openLogsStreams() {
+	char tmp[256] = "";
+	std::string path = configService.getValue<std::string>(ConfigFieldEnum::OUTPUT_DATA_DIR_);
+	sprintf(tmp, "%s/main.txt", path.c_str());
+	logStreams.mainReportStream.open(tmp);
+	sprintf(tmp, "%s/points.txt", path.c_str());
+	logStreams.pointsStream.open(tmp);
+	sprintf(tmp, "%s/pose.txt", path.c_str());
+	logStreams.poseStream.open(tmp);
+}
+
+void closeLogsStreams() {
+	logStreams.mainReportStream.close();
+	logStreams.pointsStream.close();
+	logStreams.poseStream.close();
+}
 
 void sortGlobs(std::vector<String> &paths) {
     std::sort(paths.begin(), paths.end(), [](const String &a, const String &b) {

--- a/src/IOmisc.h
+++ b/src/IOmisc.h
@@ -1,9 +1,27 @@
 #pragma once
 
-#include "main_config.h"
 #include <opencv2/videoio.hpp>
+#include "fstream"
 
 using namespace cv;
+
+typedef struct LogFilesStreams {
+	std::ofstream mainReportStream;
+	std::ofstream pointsStream;
+	std::ofstream poseStream;
+} LogFilesStreams;
+
+extern LogFilesStreams logStreams;
+
+/**
+ * Opens streams for fields of LogFilesStreams' global structure.
+ */
+void openLogsStreams();
+
+/**
+ * Closes streams for fields of LogFilesStreams' global structure.
+ */
+void closeLogsStreams();
 
 /**
  * Sorts files photos paths by its numbers.

--- a/src/cameraCalibration.cpp
+++ b/src/cameraCalibration.cpp
@@ -6,7 +6,7 @@
 #include <ctime>
 #include <iostream>
 
-#include "main_config.h"
+#include "config/config.h"
 #include "cameraCalibration.h"
 #include "IOmisc.h"
 
@@ -14,7 +14,7 @@
 
 using namespace cv;
 
-void calibration(Mat& cameraMatrix, CalibrationOption option, const char *pathToXML) {
+void calibration(Mat& cameraMatrix, CalibrationOption option) {
     VideoCapture cap;
     std::vector<String> files;
     switch (option) {
@@ -32,7 +32,8 @@ void calibration(Mat& cameraMatrix, CalibrationOption option, const char *pathTo
             break;
         default:;
     }
-    loadMatrixFromXML(pathToXML, cameraMatrix);
+	std::string pathToXML = configService.getValue<std::string>(ConfigFieldEnum::CALIBRATION_PATH_);
+    loadMatrixFromXML(pathToXML.c_str(), cameraMatrix);
 }
 
 /**
@@ -55,8 +56,11 @@ static void getObjectPoints(std::vector<Point3f> &objectPoints, Size boardSize, 
     }
 }
 
-void chessboardVideoCalibration(cv::VideoCapture capture, int itersCount, double delay, double squareSize, cv::Size boardSize,
-                                const char *pathToXML) {
+void chessboardVideoCalibration(
+	cv::VideoCapture capture, int itersCount, double delay,
+	double squareSize, cv::Size boardSize
+) {
+	bool visualCalib = configService.getValue<bool>(ConfigFieldEnum::VISUAL_CALIBRATION);
     // Set base plane pattern relative predicted points
     std::vector<Point3f> objectPoints;
     getObjectPoints(objectPoints, boardSize, squareSize);
@@ -83,23 +87,20 @@ void chessboardVideoCalibration(cv::VideoCapture capture, int itersCount, double
             cornerSubPix(gray, imagePoints, Size(11, 11), Size(-1, -1),
                          { TermCriteria(TermCriteria::COUNT + TermCriteria::EPS,30,0.0001) }
             ); // Make points' corners more precisely
-#ifdef VISUAL_CALIB
-            drawChessboardCorners(frame, boardSize, imagePoints, true);
-#endif
+			if (visualCalib)
+	            drawChessboardCorners(frame, boardSize, imagePoints, true);
             imagePointsVector.push_back(imagePoints);
             objectPointsVector.push_back(objectPoints);
             prevClock = clock();
         }
-#ifdef VISUAL_CALIB
-        char c = (char)waitKey(33);
-//        Mat resized;
-        namedWindow("Test", cv::WINDOW_NORMAL);
-        resizeWindow("Test", frame.rows / 32, frame.cols / 32);
-        imshow("Test", frame);
-//        imwrite("./test.jpg", frame);
-        if (c == 27)
-            break;
-#endif
+		if (visualCalib) {
+			char c = (char) waitKey(33);
+			namedWindow("Test", cv::WINDOW_NORMAL);
+			resizeWindow("Test", frame.rows / 32, frame.cols / 32);
+			imshow("Test", frame);
+			if (c == 27)
+				break;
+		}
     }
     if (imagePointsVector.size() < MINIMAL_FOUND_FRAMES_COUNT) {
         std::cerr << "Cannot find enough chessboard frames" << std::endl;
@@ -112,13 +113,16 @@ void chessboardVideoCalibration(cv::VideoCapture capture, int itersCount, double
             cameraMatrixK, distortionCoeffs, R, T
     );
 
-    if (pathToXML != nullptr)
-        saveCalibParametersToXML(pathToXML, cameraMatrixK, distortionCoeffs, R, T);
+	std::string pathToXML = configService.getValue<std::string>(ConfigFieldEnum::CALIBRATION_PATH_);
+	saveCalibParametersToXML(pathToXML.c_str(), cameraMatrixK, distortionCoeffs, R, T);
 }
 
-void chessboardPhotosCalibration(std::vector<String> &fileNames, int itersCount, double squareSize, Size boardSize,
-                                 const char *pathToXML) {
-    // Set base plane pattern relative predicted points
+void chessboardPhotosCalibration(
+	std::vector<String> &fileNames, int itersCount,
+	double squareSize, Size boardSize
+) {
+	bool visualCalib = configService.getValue<bool>(ConfigFieldEnum::VISUAL_CALIBRATION);
+	// Set base plane pattern relative predicted points
     std::vector<Point3f> objectPoints;
     getObjectPoints(objectPoints, boardSize, squareSize);
     std::vector <std::vector<Point3f>> objectPointsVector; // All vector is the same as its first element
@@ -143,17 +147,16 @@ void chessboardPhotosCalibration(std::vector<String> &fileNames, int itersCount,
             cornerSubPix(gray, imagePoints, Size(11, 11), Size(-1, -1),
                          { TermCriteria(TermCriteria::COUNT + TermCriteria::EPS,30,0.0001) }
             ); // Make points' corners more precisely
-#ifdef VISUAL_CALIB
-            drawChessboardCorners(frame, boardSize, imagePoints, true);
-#endif
+			if (visualCalib)
+				drawChessboardCorners(frame, boardSize, imagePoints, true);
             imagePointsVector.push_back(imagePoints);
             objectPointsVector.push_back(objectPoints);
-#ifdef VISUAL_CALIB
-            imshow("Test", frame);
-            char c = (char)waitKey(500);
-            if (c == 27)
-                break;
-#endif
+			if (visualCalib) {
+				imshow("Test", frame);
+				char c = (char) waitKey(500);
+				if (c == 27)
+					break;
+			}
         }
         else {
             std::cout << "Cannot find chessboard corners" << std::endl;
@@ -173,6 +176,6 @@ void chessboardPhotosCalibration(std::vector<String> &fileNames, int itersCount,
             cameraMatrixK, distortionCoeffs, R, T
     );
 
-    if (pathToXML != nullptr)
-        saveCalibParametersToXML(pathToXML, cameraMatrixK, distortionCoeffs, R, T);
+	std::string pathToXML = configService.getValue<std::string>(ConfigFieldEnum::CALIBRATION_PATH_);
+	saveCalibParametersToXML(pathToXML.c_str(), cameraMatrixK, distortionCoeffs, R, T);
 }

--- a/src/cameraCalibration.h
+++ b/src/cameraCalibration.h
@@ -27,7 +27,7 @@ enum CalibrationOption {
  * @param [in] option Option that determines how calibration wrapper will get calibration matrix.
  * @param [in] pathToXML Path to XML file for saving/loading. Relative path starts from project root.
  */
-void calibration(Mat& cameraMatrix, CalibrationOption option, const char* pathToXML= CALIBRATION_PATH);
+void calibration(Mat& cameraMatrix, CalibrationOption option);
 
 /**
  * Chessboard calibration from video source.
@@ -42,8 +42,7 @@ void calibration(Mat& cameraMatrix, CalibrationOption option, const char* pathTo
  * @param [in] pathToXML Oath to XML for saving got matrix
  */
 void chessboardVideoCalibration(VideoCapture capture, int itersCount= 10, double delay= 3,
-                                double squareSize= 23.0, Size boardSize= Size(7, 7),
-                                const char* pathToXML= CALIBRATION_PATH);
+                                double squareSize= 23.0, Size boardSize= Size(7, 7));
 /**
  * Chessboard calibration from photos.
  *
@@ -56,5 +55,4 @@ void chessboardVideoCalibration(VideoCapture capture, int itersCount= 10, double
  * @param [in] pathToXML Oath to XML for saving got matrix
  */
 void chessboardPhotosCalibration(std::vector<String>& fileNames, int itersCount= 10,
-                                double squareSize= 23.0, Size boardSize= Size(7, 7),
-                                const char* pathToXML= CALIBRATION_PATH);
+                                double squareSize= 23.0, Size boardSize= Size(7, 7));

--- a/src/cameraTransition.cpp
+++ b/src/cameraTransition.cpp
@@ -4,7 +4,7 @@
 #include <opencv2/core/hal/hal.hpp>
 
 #include "cameraTransition.h"
-#include "main_config.h"
+#include "config/config.h"
 
 using namespace cv;
 
@@ -30,69 +30,36 @@ bool estimateTransformation(
 ) {
 	Mat mask;
 	double maskNonZeroElemsCnt = 0;
-#ifdef USE_RANSAC
-	Mat essentialMatrix = findEssentialMat(points1, points2, calibrationMatrix, RANSAC,
-										   RANSAC_PROB, RANSAC_THRESHOLD, mask);
-#else
-	Mat essentialMatrix = findEssentialMat(points1, points2, calibrationMatrix);
-#endif
+	bool useRANSAC = configService.getValue<bool>(ConfigFieldEnum::RP_USE_RANSAC);
+	Mat essentialMatrix;
+	if (useRANSAC)
+		essentialMatrix = findEssentialMat(
+			points1, points2, calibrationMatrix, RANSAC,
+		   configService.getValue<double>(ConfigFieldEnum::RP_RANSAC_PROB),
+		   configService.getValue<double>(ConfigFieldEnum::RP_RANSAC_THRESHOLD),
+		   mask
+	   );
+	else
+		essentialMatrix = findEssentialMat(points1, points2, calibrationMatrix);
 	if (essentialMatrix.empty())
 		return false;
 
-#ifdef USE_RANSAC
-	maskNonZeroElemsCnt = countNonZero(mask);
-	std::cout << "Used in RANSAC E matrix estimation: " << maskNonZeroElemsCnt << std::endl;
+	if (useRANSAC) {
+		maskNonZeroElemsCnt = countNonZero(mask);
+		std::cout << "Used in RANSAC E matrix estimation: " << maskNonZeroElemsCnt << std::endl;
 //    if ((maskNonZeroElemsCnt / points1.size()) < RANSAC_GOOD_POINTS_PERCENT)
 //        return false;
-#endif
+	}
 
 	// Find P matrix using wrapped OpenCV SVD and triangulation
-	int passedPointsCount = recoverPose(essentialMatrix, points1, points2, calibrationMatrix,
-										rotationMatrix, translationVector,
-										RECOVER_POSE_DISTANCE_THRESHOLD, chiralityMask);
+	int passedPointsCount = recoverPose(
+		essentialMatrix, points1, points2, calibrationMatrix,
+		rotationMatrix, translationVector,
+		configService.getValue<double>(ConfigFieldEnum::RP_DISTANCE_THRESHOLD),
+		chiralityMask
+	);
 	maskNonZeroElemsCnt = countNonZero(chiralityMask);
 	std::cout << "Passed chirality check cnt: " << maskNonZeroElemsCnt << std::endl;
-	return passedPointsCount > 0;
-}
-
-bool estimateProjection(std::vector<Point2f>& points1, std::vector<Point2f>& points2, const Mat& calibrationMatrix,
-	Mat& rotationMatrix, Mat& translationVector, Mat& projectionMatrix, Mat& triangulatedPoints)
-{
-
-    Mat mask;
-	double maskNonZeroElemsCnt = 0;
-#ifdef USE_RANSAC
-	Mat essentialMatrix = findEssentialMat(points1, points2, calibrationMatrix, RANSAC,
-                                           RANSAC_PROB, RANSAC_THRESHOLD, mask);
-#else
-    Mat essentialMatrix = findEssentialMat(points1, points2, calibrationMatrix);
-#endif
-    if (essentialMatrix.empty())
-        return false;
-
-#ifdef USE_RANSAC
-    maskNonZeroElemsCnt = countNonZero(mask);
-    std::cout << "Used in RANSAC E matrix estimation: " << maskNonZeroElemsCnt << std::endl;
-#ifdef USE_RANSAC_POINTS_FILTER
-    filterVectorByMask(points1, mask);
-    filterVectorByMask(points2, mask);
-#endif
-//    if ((maskNonZeroElemsCnt / points1.size()) < RANSAC_GOOD_POINTS_PERCENT)
-//        return false;
-#endif
-
-	// Find P matrix using wrapped OpenCV SVD and triangulation
-    Mat recoverMask;
-	int passedPointsCount = recoverPose(essentialMatrix, points1, points2, calibrationMatrix,
-                                        rotationMatrix, translationVector,
-                                        RECOVER_POSE_DISTANCE_THRESHOLD, recoverMask, triangulatedPoints);
-	hconcat(rotationMatrix, translationVector, projectionMatrix);
-    maskNonZeroElemsCnt = countNonZero(recoverMask);
-    std::cout << "Passed cherality check cnt: " << maskNonZeroElemsCnt << std::endl;
-#ifdef USE_RECOVER_POSE_POINTS_FILTER
-    filterVectorByMask(points1, recoverMask);
-    filterVectorByMask(points2, recoverMask);
-#endif
 	return passedPointsCount > 0;
 }
 

--- a/src/config/configData.h
+++ b/src/config/configData.h
@@ -15,6 +15,7 @@ typedef struct ConfigFieldPair {
 
 enum ConfigFieldEnum {
 	CALIBRATE,
+	VISUAL_CALIBRATION,
 	CALIBRATION_PATH_,
 
 	USE_PHOTOS_CYCLE,
@@ -56,6 +57,7 @@ enum ConfigFieldEnum {
 
 const std::map<ConfigFieldEnum, ConfigFieldPair> configFields = {
 		{CALIBRATE,{"calibrate", BOOL}},
+		{VISUAL_CALIBRATION,{"visualCalibration", BOOL}},
 		{CALIBRATION_PATH_,{"calibrationPath", STRING}},
 
 		{USE_PHOTOS_CYCLE,{"usePhotosCycle", BOOL}},
@@ -90,5 +92,5 @@ const std::map<ConfigFieldEnum, ConfigFieldPair> configFields = {
 		{RP_RANSAC_PROB,{"RPRANSACProb", FLOATING}},
 		{RP_RANSAC_THRESHOLD,{"RPRANSACThreshold", FLOATING}},
 		{RP_REQUIRED_GOOD_POINTS_PERCENT,{"RPRequiredGoodPointsPercent", FLOATING}},
-		{RP_DISTANCE_THRESHOLD,{"RPDistanceTreshold", INTEGER}},
+		{RP_DISTANCE_THRESHOLD,{"RPDistanceThreshold", FLOATING}},
 };

--- a/src/featureMatching.cpp
+++ b/src/featureMatching.cpp
@@ -16,6 +16,7 @@ MatcherType getMatcherTypeIndex() {
 		return MatcherType::SIFT_FLANN;
 	if (configService.getValue<bool>(ConfigFieldEnum::FM_ORB_))
 		return MatcherType::ORB_BF;
+	throw new std::exception();
 }
 
 void getMatchedPoints(

--- a/src/featureMatching.cpp
+++ b/src/featureMatching.cpp
@@ -2,13 +2,11 @@
 #include <opencv2/opencv.hpp>
 #include <opencv2/core.hpp>
 
-#include <opencv2/videoio.hpp>
 #include <opencv2/highgui.hpp>
 
 #include "featureMatching.h"
 
 #include "config/config.h"
-#include "main_config.h"
 using namespace cv;
 
 MatcherType getMatcherTypeIndex() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,16 @@
 #include "cameraCalibration.h"
 #include "IOmisc.h"
 #include "fstream"
-#include "nlohmann/json.hpp"
 
 #include "mainCycle.h"
 #include "config/config.h"
 #include "featureMatching.h"
 
-#include "main_config.h"
 
 using namespace cv;
 
 ConfigService configService;
+LogFilesStreams logStreams;
 
 int main(int argc, char** argv)
 {
@@ -20,10 +19,14 @@ int main(int argc, char** argv)
 		return 2;
 	}
 	configService.setConfigFile(argv[1]);
+	openLogsStreams();
 
 	if (configService.getValue<bool>(ConfigFieldEnum::CALIBRATE)) {
 		std::vector<String> files;
-		glob("../static/for_calib/samsung-hv/*.png", files, false);
+		glob(
+			configService.getValue<std::string>(ConfigFieldEnum::PHOTOS_PATH_PATTERN_),
+			files, false
+		);
 		chessboardPhotosCalibration(files, 13);
 		return 0;
 	}
@@ -56,5 +59,6 @@ int main(int argc, char** argv)
 			configService.getValue<float>(ConfigFieldEnum::FM_SEARCH_RADIUS_)
 	   );
 	}
+	closeLogsStreams();
     return 0;
 }

--- a/src/mainCycle.h
+++ b/src/mainCycle.h
@@ -18,14 +18,6 @@ typedef struct DataProcessingConditions {
     float radius;                     // Matching radius.
 } DataProcessingConditions;
 
-typedef struct LogFilesStreams {
-    std::ofstream mainReportStream;
-    std::ofstream pointsStream;
-    std::ofstream poseStream;
-    std::ofstream poseHandyStream;
-    std::ofstream poseGlobalMltStream;
-} LogFilesStreams;
-
 /**
  * Struct containing temporal image data.
  */
@@ -230,10 +222,10 @@ void getObjAndImgPoints(
  * @param [out] secondMatchedPoints Output vector to store the matched keypoints' coordinates from the second image.
  */
 void getMatchedPointCoords(
-	std::vector<KeyPoint> &firstExtractedFeatures, 
-	std::vector<KeyPoint> &secondExtractedFeatures, 
-	std::vector<DMatch> &matches, 
-	std::vector<Point2f> &firstMatchedPoints, 
+	std::vector<KeyPoint> &firstExtractedFeatures,
+	std::vector<KeyPoint> &secondExtractedFeatures,
+	std::vector<DMatch> &matches,
+	std::vector<Point2f> &firstMatchedPoints,
 	std::vector<Point2f> &secondMatchedPoints
 );
 

--- a/src/triangulate.cpp
+++ b/src/triangulate.cpp
@@ -1,6 +1,3 @@
-#include <iostream>
-
-#include "opencv2/calib3d.hpp"
 #include "opencv2/core/core_c.h"
 
 #include "triangulate.h"
@@ -104,16 +101,16 @@ void convertHomogeneousPointsMatrixToSpatialPointsVector(
 )
 {
 	spatialPoints.clear();
-	float w;
+	double w;
 	Mat pointCol = Mat::zeros(4, 1, CV_64F);
 	for (int col = 0; col < homogeneous3DPoints.cols; ++col) {
-		w = homogeneous3DPoints.at<float>(3, col);
+		w = homogeneous3DPoints.at<double>(3, col);
 		pointCol = homogeneous3DPoints.col(col);
 		pointCol /= w;
 		spatialPoints.emplace_back(
-			pointCol.at<float>(0),
-			pointCol.at<float>(1),
-			pointCol.at<float>(2)
+			pointCol.at<double>(0),
+			pointCol.at<double>(1),
+			pointCol.at<double>(2)
 		);
 	}
 }


### PR DESCRIPTION
Пока тестировал цикл, внёс кое-какие изменения, которые уже не хочу пушить напрямую в ту ветку, но и оставлять локально не хочу:
- Пофиксил баг, из-за которого значения были просто дикими
- Добавил вывод данных в репорт-потоки (черновая версия)
- Перешёл в тех местах, где ещё нет, на новый конфигурационный метод. Теперь из `main_config.h` берутся только куски для трекера. Все остальные изменения теперь надо делать в `config.json`

P.S. Исправил очепятку в `config.json` (в последнем поле) и добавил поле для визуализации калибровки. Вот актуальная версия конфига:
```json
{
  "calibrate": false,
  "visualCalibration": true,
  "calibrationPath": "./config/samsung-hv.xml",

  "usePhotosCycle": false,
  "photosPathPattern": "/mnt/c/Users/bakug/YandexDisk/NSU/private/2-1/PAK/static/photos/samsung-tumbochka-s/*.JPG",
  // "videoSourcePath" has an effect when "usePhotosCycle" is false
  "videoSourcePath": "/mnt/c/Users/bakug/YandexDisk/NSU/private/2-1/PAK/static/samsung_table_from_photos.mp4",
  
  "outputDataDir": "./data/video_report/video_test",
  
  "useUndistortion": false,

  "requiredExtractedPointsCount": 50,
  "featureExtractingThreshold": 20,

  "framesBatchSize": 4,

  "useFeatureTracker": false,
  // This block has an effect when "useFeatureTracker" is true
  "useOwnFeatureTracker": true,
  "FTThreadsCount": 3,
  "useSADOwnFT": true,
  "useSSDOwnFT": false,
  "FTBarrier": 20,
  "FTMaxAcceptableDifference": 2000,
  
  // This block has an effect when "useFeatureTracker" is false
  "useFM-SIFT-FLANN": true,
  "useFM-SIFT-BF": false,
  "useFM-ORB": false,
  "featureMatchingRadius": 200.0,
  "showTrackedPoints": true,

  "RPUseRANSAC": true,
  "RPRANSACProb": 0.999,
  "RPRANSACThreshold": 5.0,
  "RPRequiredGoodPointsPercent": 0.5,
  "RPDistanceThreshold": 500.0
}
```